### PR TITLE
Fix: test_getvehicle() queried for a non-existing vehicle

### DIFF
--- a/test.py
+++ b/test.py
@@ -2,17 +2,17 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2011, Wouter Horré
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -54,7 +54,7 @@ def test_getliveboard():
 
 def test_getvehicle():
   api = iRailAPI()
-  schedule = api.get_vehicle_by_id("Be.NMBS.P1234")
+  schedule = api.get_vehicle_by_id("BE.NMBS.L584")
   print schedule
 
 if __name__=="__main__":


### PR DESCRIPTION
Noticed that the test.py script failed on test_getvehicle().
The used ID does no longer exist. Replaced it with an existing one.
