### PR TITLE
Port the lib to Python 3

### DIFF
--- a/irail/api.py
+++ b/irail/api.py
@@ -20,10 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import urllib2
-from model import *
-from format import *
-from exception import *
+import urllib.request, urllib.error, urllib.parse
+from .model import *
+from .format import *
+from .exception import *
 
 #curl 'api.irail.be/liveboard/?station=gentbruggee&format=json'
 
@@ -65,11 +65,11 @@ class iRailAPI:
     url += "?format=" + str(self.format())
     url += "&lang=" + self.lang()
     if args:
-      for key in args.keys():
+      for key in list(args.keys()):
         url += "&" + key + "=" + args[key]
     try:
-      return urllib2.urlopen(url)
-    except urllib2.HTTPError as e:
+      return urllib.request.urlopen(url)
+    except urllib.error.HTTPError as e:
       if e.code >= 400 and e.code < 500:
         raise ClientError(e)
       elif e.code >= 500 and e.code < 500:

--- a/irail/format.py
+++ b/irail/format.py
@@ -71,7 +71,7 @@ class JsonFormat:
     time = dict['time']
     delay = dict['delay']
     vehicle = dict['vehicle']
-    direction = self.__convert_station(dict['direction'])
+    direction = Station(dict['direction']['name'], *[None]*4)  # Direction is not a real station
     return clazz(station, platform, time, delay, vehicle, direction)
 
   def __convert_arrival(self, dict):

--- a/irail/format.py
+++ b/irail/format.py
@@ -22,7 +22,7 @@
 
 import json
 
-from model import *
+from .model import *
 
 class JsonFormat:
 
@@ -55,7 +55,7 @@ class JsonFormat:
 
   def __convert_schedule(self, dict):
     departure = self.__convert_departure(dict['departure'])
-    if dict.has_key('vias'):
+    if 'vias' in dict:
       vias = self.__convert_vias(dict['vias'])
     else:
       vias = None

--- a/irail/model.py
+++ b/irail/model.py
@@ -32,7 +32,7 @@ class ObjectFactory(object):
       return [ObjectFactory(e) for e in d] #TODO add tuple, set, frozenset
     elif isinstance(d, dict):
       obj = object.__new__(cls)
-      for k, v in d.iteritems():
+      for k, v in d.items():
         setattr(obj, k, ObjectFactory(v))
       return obj
     else:
@@ -40,7 +40,7 @@ class ObjectFactory(object):
 
   def __repr__(self):
     return '<%s>' % str('\n '.join('%s : %s' %
-      (k, repr(v)) for (k, v) in self.__dict__.iteritems()))
+      (k, repr(v)) for (k, v) in self.__dict__.items()))
   
 class ResultList:
   def __init__(self, timestamp, version):

--- a/test.py
+++ b/test.py
@@ -27,35 +27,35 @@ from irail.api import iRailAPI
 def test_getstations():
   api = iRailAPI()
   r = api.get_stations()
-  print "Version: " + r.version()
-  print "Timestamp: " + r.timestamp()
+  print("Version: " + r.version())
+  print("Timestamp: " + r.timestamp())
   for station in r.stations():
-    print station
+    print(station)
 
 def test_searchstations():
   api = iRailAPI()
   stations = api.search_stations("bru")
-  print "--- Stations starting with bru ---"
+  print("--- Stations starting with bru ---")
   for station in stations:
-    print station
+    print(station)
 
 def test_getschedules():
   api = iRailAPI()
   schedules = api.get_schedules_by_names("Courtrai", "Leuven")
   for schedule in schedules.connections():
-    print schedule
+    print(schedule)
 
 def test_getliveboard():
   api = iRailAPI()
   schedule = api.get_liveboard_by_name("Gentbrugge")
-  print schedule
+  print(schedule)
   #schedule = api.get_liveboard_by_id("BE.NMBS.008893179")
   #print schedule
 
 def test_getvehicle():
   api = iRailAPI()
   schedule = api.get_vehicle_by_id("BE.NMBS.L584")
-  print schedule
+  print(schedule)
 
 if __name__=="__main__":
 #  test_getstations()


### PR DESCRIPTION
Hello,

I ported the lib to Python 3 quite easily by simply running the 2to3 tool. I also fixed a bug preventing the test suite to complete without errors.

Maybe this should not be merged directly into the master branch, but judging by the recent activity, or rather the lack thereof, I doubt that the Python2 branch will receive any future updates. Actually, moving the Python2 version in a separate branch would be the best choice in my opinion.
I intend on developing the lib further in the future. In fact I already started rewriting its internals while keeping the API untouched, but that will be the matter of another pull request.